### PR TITLE
Fix TokenAndPositionEmbedding Class in Keras Transformer

### DIFF
--- a/NLP_assignment_GT_solo_transformer_keras.ipynb
+++ b/NLP_assignment_GT_solo_transformer_keras.ipynb
@@ -125,18 +125,18 @@
     "from keras.layers import GlobalMaxPooling1D\n",
     "from keras.layers import BatchNormalization\n",
     "\n",
-    "class TokenAndPositionEmbedding(Layer):\n",
-    "    def __init__(self, maxlen, vocab_size, embed_dim):\n",
-    "        super(TokenAndPositionEmbedding, self).__init__()\n",
-    "        self.token_emb = Embedding(input_dim=vocab_size, output_dim=embed_dim)\n",
-    "        self.pos_emb = Embedding(input_dim=maxlen, output_dim=embed_dim)\n",
-    "\n",
-    "    def call(self, x):\n",
-    "        maxlen = K.shape(x)[-1]\n",
-    "        positions = tf.range(start=0, limit=maxlen, delta=1)\n",
-    "        positions = self.pos_emb(positions)\n",
-    "        x = self.token_emb(x)\n",
-    "        return x + positions\n",
+    "class TokenAndPositionEmbedding(Layer):
+    def __init__(self, maxlen, vocab_size, embed_dim, **kwargs):
+        super(TokenAndPositionEmbedding, self).__init__(**kwargs)
+        self.maxlen = maxlen
+        self.token_emb = Embedding(input_dim=vocab_size, output_dim=embed_dim)
+        self.pos_emb = Embedding(input_dim=maxlen, output_dim=embed_dim)
+
+    def call(self, x):
+        positions = tf.range(start=0, limit=self.maxlen, delta=1)
+        positions = self.pos_emb(positions)
+        x = self.token_emb(x)
+        return x + positions\n",
     "    \n",
     "class TransformerBlock(Layer):\n",
     "    def __init__(self, embed_dim, num_heads, ff_dim, rate=0.1):\n",


### PR DESCRIPTION
This pull request modifies the `TokenAndPositionEmbedding` class in the Keras transformer implementation. The changes include:

- Added `**kwargs` to the constructor to allow for additional arguments.
- Stored `maxlen` as an instance variable to avoid recalculating it in the `call` method.
- Simplified the `call` method by directly using `self.maxlen` instead of calling `K.shape(x)[-1]`.

These modifications aim to improve the efficiency and flexibility of the embedding layer, addressing issues encountered during the development of the transformer model.

---

> This pull request was co-created with Cosine Genie

Original Task: [Transformer_KERAS/l9u5h6ebgu8a](https://cosine.sh/36kxaxnzhm1k/Transformer_KERAS/task/l9u5h6ebgu8a)
Author: Gianfranco Tomaino
